### PR TITLE
Remove usage of $HOME

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,6 @@ ENV_DIR=$3
 
 echo RootDir: $ROOT_DIR
 echo BuildDir: $BUILD_DIR
-echo HOME: $HOME
 
 mkdir -p $BUILD_DIR/vendor/libmagic/include/
 mkdir -p $BUILD_DIR/vendor/libmagic/lib/
@@ -27,5 +26,3 @@ EOF
 
 echo "Build list"
 ls $BUILD_DIR/.bundle
-echo "Home list"
-ls $HOME/.bundle


### PR DESCRIPTION
Since at build time, `$HOME` is set to `/app`, which is where the build
system lives and so no assumptions should be made about its contents.

Removing this fixes the error:

`ls: cannot access '/app/.bundle': No such file or directory`

Fixes #1.